### PR TITLE
Remove Prove identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Prove - Community Health Files
+# Checkmango - Community Health Files
 
-This repository contains the default [community health files](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) for the [`prove-dev`](https://github.com/prove-dev) organisation.
+This repository contains the default [community health files](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file) for the [`checkmango`](https://github.com/checkmango) organisation.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,1 +1,3 @@
-Prove... coming soon!
+<p align="center"><img src="https://checkmango.com/img/logo.svg" width="400" title="Checkmango" alt="Checkmango"></p>
+
+Checkmango... coming soon!


### PR DESCRIPTION
Since you mentioned on [Twitter](https://twitter.com/jbrooksuk/status/1491153024001064960) that you received a cease and desist letter, thought it might be prudent to update the identity on the org. 🙂

Not sure about including the logo directly from the site. Maybe adding it to an `art` repo or an `art` folder to save bandwidth? Up to you. It is such a good logo so it would be a shame not to show it off.

Just noticed that the Twitter account on the org points to the wrong account as well.